### PR TITLE
fix: add missing message

### DIFF
--- a/mod_updater.py
+++ b/mod_updater.py
@@ -452,7 +452,7 @@ class ModUpdater():
                 self._print_mod_message(
                         mod=mod,
                         version=version,
-                        action='skip',
+                        action='Skip',
                         result='N/A',
                         message='Missing metadata, skipping update!')
                 continue
@@ -463,7 +463,7 @@ class ModUpdater():
                 self._print_mod_message(
                         mod=mod,
                         version=version,
-                        action='skip',
+                        action='Skip',
                         result='N/A',
                         message=message)
                 continue

--- a/mod_updater.py
+++ b/mod_updater.py
@@ -518,7 +518,7 @@ class ModUpdater():
             self._print_mod_message(
                     mod=mod,
                     version=rel_ver,
-                    action='remove',
+                    action='Remove',
                     result=result,
                     message=message)
 
@@ -556,6 +556,7 @@ class ModUpdater():
             else:
                 result = 'Failure'
                 download = True
+                message = "Validation failed, downloading again"
             self._print_mod_message(
                     mod=mod,
                     version=v_cur,


### PR DESCRIPTION
A message declaration was missing for one the download scenario where a mod on the latest version exists but doesn't match the checksum.

This change simply adds that message and also makes all of the actions title case.

Closes #9 