### PR TITLE
1.1 and 1.0 aren't compatible.

### DIFF
--- a/mod_updater.py
+++ b/mod_updater.py
@@ -48,8 +48,6 @@ def _version_match(installed: str, mod: str):
     """Checks if factorio versions are compatible."""
     if installed.startswith("1.") and mod == "0.18":
         return True
-    if installed.startswith("1.") and mod.startswith("1."):
-        return int(installed[2:]) >= int(mod[2:])
     return installed == mod
 
 


### PR DESCRIPTION
Fixes a bug in latest PR. Didn't realise when I created it that 1.0 mods don't work on 1.1, and that the only exception is compatibility between 1.0 and 0.18.